### PR TITLE
chore: update all GitHub Actions to latest versions with SHA pinning

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -29,23 +29,23 @@ jobs:
     steps:
       - name: Auto-assign Copilot to issue
         if: github.event_name == 'issues'
-        uses: pozil/auto-assign-issue@v2.1.0
+        uses: pozil/auto-assign-issue@39c06395cbac76e79afc4ad4e5c5c6db6ecfdd2e # v2.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: copilot
           numOfAssignee: 1
-      
+
       - name: Auto-assign Copilot to PR
         if: github.event_name == 'pull_request'
-        uses: pozil/auto-assign-issue@v2.1.0
+        uses: pozil/auto-assign-issue@39c06395cbac76e79afc4ad4e5c5c6db6ecfdd2e # v2.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: copilot
           numOfAssignee: 1
-          
+
       - name: Add triage label to issues
         if: github.event_name == 'issues'
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.issues.addLabels({

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -45,12 +45,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0d1933529914177075d5bc3558ae3d047f188146 # v1.0.26
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -68,12 +68,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0d1933529914177075d5bc3558ae3d047f188146 # v1.0.26
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -188,7 +188,7 @@ jobs:
 
       - name: Claude Review (on mention)
         if: steps.reviewer.outputs.reviewer == 'claude'
-        uses: anthropics/claude-code-action@f0c8eb29807907de7f5412d04afceb5e24817127 # v1
+        uses: anthropics/claude-code-action@0d1933529914177075d5bc3558ae3d047f188146 # v1.0.26
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -66,14 +66,14 @@ jobs:
 
       - name: Add to Integration Project
         if: steps.issue.outputs.add_integration == 'true'
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/jbcom/projects/2
           github-token: ${{ secrets.CI_GITHUB_TOKEN }}
 
       - name: Add to Roadmap Project
         if: steps.issue.outputs.add_roadmap == 'true'
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/jbcom/projects/8
           github-token: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/sync-files.yml
+++ b/.github/workflows/sync-files.yml
@@ -47,8 +47,8 @@ jobs:
     outputs:
       repos: ${{ steps.repos.outputs.repos }}
     steps:
-      - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
       - name: Build repo list
         id: repos
         run: |
@@ -90,12 +90,12 @@ jobs:
           fi
 
       - name: Checkout .github repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           path: source
-      
+
       - name: Setup SSH agent
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.REPO_SYNC_SSH_KEY }}
       

--- a/sync-files/initial-only/.github/workflows/docs.yml
+++ b/sync-files/initial-only/.github/workflows/docs.yml
@@ -21,15 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
         with:
           version: "latest"
 
@@ -45,10 +45,10 @@ jobs:
         run: touch docs/_build/html/.nojekyll
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: 'docs/_build/html'
 
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary
- Updates all GitHub Actions to their latest versions with exact SHA pinning for security
- SHA pinning prevents supply chain attacks and ensures reproducible builds

## Actions Updated
| Action | Old Version | New Version | SHA |
|--------|-------------|-------------|-----|
| actions/checkout | v4 | v6.0.1 | 8e8c483db84b4bee98b60c0593521ed34d9990e8 |
| actions/github-script | v7.0.1 | v8.0.0 | ed597411d8f924073f98dfc5c65a23a2325f34cd |
| anthropics/claude-code-action | v1 | v1.0.26 | 0d1933529914177075d5bc3558ae3d047f188146 |
| pozil/auto-assign-issue | v2.1.0 | v2.2.0 | 39c06395cbac76e79afc4ad4e5c5c6db6ecfdd2e |
| webfactory/ssh-agent | v0.9.0 | v0.9.1 | a6f90b1f127823b31d4d4a8d96047790581349bd |
| actions/add-to-project | v1.0.2 | v1.0.2 | 244f685bbc3b7adfa8466e08b698b5577571133e |
| actions/setup-python | v5 | v6.1.0 | 83679a892e2d95755f2dac6acb0bfd1e9ac5d548 |
| astral-sh/setup-uv | v4 | v7.1.6 | 681c641aba71e4a1c380be3ab5e12ad51f415867 |
| actions/configure-pages | v5 | v5.0.0 | 983d7736d9b0ae728b81ab479565c72886d7745b |
| actions/upload-pages-artifact | v3 | v4.0.0 | 7b1f4a764d45c48632c6b24a0339c27f5614fb0b |
| actions/deploy-pages | v4 | v4.0.5 | d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e |

## Files Changed
- `.github/workflows/auto-assign.yml`
- `.github/workflows/claude-code.yml`
- `.github/workflows/pr-review.yml`
- `.github/workflows/project-sync.yml`
- `.github/workflows/sync-files.yml`
- `sync-files/initial-only/.github/workflows/docs.yml`

## Test Plan
- [ ] Verify workflows trigger correctly on PR events
- [ ] Monitor workflow runs for any action compatibility issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins and upgrades multiple GitHub Actions to specific SHAs across CI workflows for security and consistency.
> 
> - **Workflows**: Pin and upgrade actions to specific SHAs
>   - `/.github/workflows/auto-assign.yml`
>     - `pozil/auto-assign-issue` → `v2.2.0` (`39c0639...`)
>     - `actions/github-script` → `v8.0.0` (`ed59741...`)
>   - `/.github/workflows/claude-code.yml`
>     - `actions/checkout` → `v6.0.1` (`8e8c483...`)
>     - `anthropics/claude-code-action` → `v1.0.26` (`0d19335...`)
>   - `/.github/workflows/pr-review.yml`
>     - `anthropics/claude-code-action` → `v1.0.26` (`0d19335...`)
>     - `actions/github-script` → `v8` (`ed59741...`)
>   - `/.github/workflows/project-sync.yml`
>     - `actions/add-to-project` pinned (`244f685...`)
>   - `/.github/workflows/sync-files.yml`
>     - `actions/checkout` → `v6.0.1` (`8e8c483...`)
>     - `webfactory/ssh-agent` → `v0.9.1` (`a6f90b1...`)
>   - `/sync-files/initial-only/.github/workflows/docs.yml`
>     - `actions/checkout` → `v6.0.1` (`8e8c483...`)
>     - `actions/setup-python` → `v6.1.0` (`83679a8...`)
>     - `astral-sh/setup-uv` → `v7.1.6` (`681c641...`)
>     - `actions/configure-pages` → `v5.0.0` (`983d773...`)
>     - `actions/upload-pages-artifact` → `v4.0.0` (`7b1f4a7...`)
>     - `actions/deploy-pages` → `v4.0.5` (`d6db901...`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df8f229c612cca7446c20c83be1283eebaabe8ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->